### PR TITLE
patch-v2 libplanes: Add ability to independently apply vertical and scale factors.

### DIFF
--- a/include/planes/plane.h
+++ b/include/planes/plane.h
@@ -75,7 +75,8 @@ struct plane_data
 	int rotate_degrees;
 	int rotate_degrees_applied;
 	/** Scale of the plane.  1.0 is no scale. */
-	double scale;
+	double scale_x;
+	double scale_y;
 	/** GEM name of the plane. */
 	uint32_t* gem_names;
 	/** Alpha value of the plane.  0 to 255. */
@@ -210,6 +211,16 @@ void plane_set_pos(struct plane_data* plane, int x, int y);
  * @see plane_apply()
  */
 void plane_set_scale(struct plane_data* plane, double scale);
+
+/**
+ * Set the plane x and y scale.
+ * You must call plane_apply() to commit the change.
+ *
+ * @param scale_x Horizontal scale of the plane, where 1.0 is no scale.
+ * @param scale_y Vertical scale of the plane, where 1.0 is no scale.
+ * @see plane_apply()
+ */
+void plane_set_scale_independent(struct plane_data* plane, double scale_x, double scale_y);
 
 /**
  * Apply the current properties of the plane.

--- a/src/engine.c
+++ b/src/engine.c
@@ -918,12 +918,15 @@ void engine_run_once(struct kms_device* device, struct plane_data** planes,
 		}
 
 		if (planes[i]->move_flags & MOVE_SCALER) {
-			if (planes[i]->scale >= planes[i]->scaler.max ||
-			    planes[i]->scale <= planes[i]->scaler.min) {
-				planes[i]->scaler.speed *= -1.0;
+			if (planes[i]->scale_x >= planes[i]->scaler.max ||
+			    planes[i]->scale_y >= planes[i]->scaler.max ||
+			    planes[i]->scale_x <= planes[i]->scaler.min ||
+			    planes[i]->scale_y <= planes[i]->scaler.min) {
+			    planes[i]->scaler.speed *= -1.0;
 			}
 
-			planes[i]->scale += planes[i]->scaler.speed;
+			planes[i]->scale_x += planes[i]->scaler.speed;
+			planes[i]->scale_y += planes[i]->scaler.speed;
 			move = true;
 		}
 

--- a/src/kms-plane.c
+++ b/src/kms-plane.c
@@ -134,13 +134,13 @@ void kms_plane_free(struct kms_plane *plane)
 }
 
 int kms_plane_set(struct kms_plane *plane, struct kms_framebuffer *fb,
-		  int x, int y, double scale)
+		  int x, int y, double scale_x, double scale_y)
 {
 	struct kms_device *device = plane->device;
 	int err;
 
-	int w = fb->width * scale;
-	int h = fb->height * scale;
+	int w = fb->width * scale_x;
+	int h = fb->height * scale_y;
 
 	err = drmModeSetPlane(device->fd, plane->id, plane->crtc->id, fb->id,
 			      0, x, y, w, h, 0 << 16,
@@ -153,13 +153,13 @@ int kms_plane_set(struct kms_plane *plane, struct kms_framebuffer *fb,
 
 int kms_plane_set_pan(struct kms_plane *plane, struct kms_framebuffer *fb,
 		      int x, int y, uint32_t px, uint32_t py, uint32_t pw,
-		      uint32_t ph, double scale)
+		      uint32_t ph, double scale_x, double scale_y)
 {
 	struct kms_device *device = plane->device;
 	int err;
 
-	int w = pw * scale;
-	int h = ph * scale;
+	int w = pw * scale_x;
+	int h = ph * scale_y;
 
 	err = drmModeSetPlane(device->fd, plane->id, plane->crtc->id, fb->id,
 			      0,

--- a/src/p_kms.h
+++ b/src/p_kms.h
@@ -69,9 +69,9 @@ void kms_plane_free(struct kms_plane *plane);
 int kms_plane_remove(struct kms_plane *plane);
 
 int kms_plane_set(struct kms_plane *plane, struct kms_framebuffer *fb,
-		  int x, int y, double scale);
+		  int x, int y, double scale_x, double scale_y);
 int kms_plane_set_pan(struct kms_plane *plane, struct kms_framebuffer *fb,
-		      int x, int y, uint32_t px, uint32_t py, uint32_t pw, uint32_t ph, double scale);
+		      int x, int y, uint32_t px, uint32_t py, uint32_t pw, uint32_t ph, double scale_x, double scale_y);
 bool kms_plane_supports_format(struct kms_plane *plane, uint32_t format);
 
 void kms_device_probe_framebuffers(struct kms_device *device);

--- a/src/plane.c
+++ b/src/plane.c
@@ -135,7 +135,8 @@ struct plane_data* plane_create_buffered(struct kms_device* device, int type,
 
 	plane->index = index;
 	plane->alpha = 255;
-	plane->scale = 1.0;
+	plane->scale_x = 1.0;
+	plane->scale_y = 1.0;
 
 	for (fb = 0; fb < plane->buffer_count;fb++) {
 		plane->gem_names[fb] = create_gem_name(plane->fbs[fb]);
@@ -304,7 +305,13 @@ void plane_set_pos(struct plane_data* plane, int x, int y)
 
 void plane_set_scale(struct plane_data* plane, double scale)
 {
-	plane->scale = scale;
+	plane_set_scale_independent(plane, scale, scale);
+}
+
+void plane_set_scale_independent(struct plane_data* plane, double scale_x, double scale_y)
+{
+	plane->scale_x = scale_x;
+	plane->scale_y = scale_y;
 }
 
 int plane_apply(struct plane_data* plane)
@@ -322,12 +329,12 @@ int plane_apply(struct plane_data* plane)
 					 plane->x, plane->y,
 					 plane->pan.x, plane->pan.y,
 					 plane->pan.width, plane->pan.height,
-					 plane->scale);
+					 plane->scale_x, plane->scale_y);
 	}
 
 	return kms_plane_set(plane->plane, fb,
 			     plane->x, plane->y,
-			     plane->scale);
+			     plane->scale_x, plane->scale_y);
 }
 
 uint32_t plane_width(struct plane_data* plane)
@@ -443,12 +450,12 @@ int plane_flip(struct plane_data* plane, uint32_t target)
 					 plane->x, plane->y,
 					 plane->pan.x, plane->pan.y,
 					 plane->pan.width, plane->pan.height,
-					 plane->scale);
+					 plane->scale_x, plane->scale_y);
 	}
 
 	return kms_plane_set(plane->plane, plane->fbs[plane->front_buf],
 			     plane->x, plane->y,
-			     plane->scale);
+			     plane->scale_x, plane->scale_y);
 }
 
 int plane_flip_async(struct plane_data* plane, uint32_t target)


### PR DESCRIPTION
libplanes: Add ability to independently apply vertical and scale factors.

Currently, the API to libplanes allows only setting a uniform scale factor that
will equally scale both width and height. At the lower kms level, the function
actually does set the width and height, so this patch simply exposes this to
the planes level to allow independent dimension scaling.

Signed-off-by: Ken Sloat <ksloat@aampglobal.com>
---
Changes in v2:
-Add a separate function for independent plane scaling for backwards API compatibility
-Squash all changes into a single commit
-Add developer's certificate of origin