### PR TITLE
kms-device.c: Add missing entries to connector_names

### DIFF
--- a/src/kms-device.c
+++ b/src/kms-device.c
@@ -54,6 +54,9 @@ static const char *const connector_names[] = {
 	"eDP",
 	"Virtual",
 	"DSI",
+	"DPI",
+	"Writeback",
+	"SPI",
 };
 
 static void kms_device_probe_screens(struct kms_device *device)


### PR DESCRIPTION
Though I'm not sure how widely libplanes is intended to support devices, I would like to report that several entries should be added to `connector_names` so that this tool can handle corresponding connector types that could be available in the target platform.

Please check the commit message for more details.
